### PR TITLE
Add libmonetdb5 path for the mal_linker in the Java version

### DIFF
--- a/src/mal/mal/mal_linker.c
+++ b/src/mal/mal/mal_linker.c
@@ -34,6 +34,23 @@
 
 #define MAXMODULES 128
 
+static char* monetDB5LibraryPath = NULL;
+
+void freeMonetDB5LibraryPath(void) {
+	if(monetDB5LibraryPath != NULL) {
+		GDKfree(monetDB5LibraryPath);
+		monetDB5LibraryPath = NULL;
+	}
+}
+
+int setMonetDB5LibraryPath(const char* path) {
+	if(monetDB5LibraryPath != NULL) {
+		freeMonetDB5LibraryPath();
+	}
+	monetDB5LibraryPath = GDKstrdup(path);
+	return monetDB5LibraryPath != NULL ? 1 : 0;
+}
+
 typedef struct{
 	str modname;
 	str fullname;
@@ -97,7 +114,7 @@ getAddress(stream *out, str modname, str fcnname, int silent)
 	 *
 	 * the first argument must be the same as the base name of the
 	 * library that is created in src/tools */
-	dl = mdlopen("libmonetdb5", RTLD_NOW | RTLD_GLOBAL);
+	dl = mdlopen(monetDB5LibraryPath ? monetDB5LibraryPath : "libmonetdb5", RTLD_NOW | RTLD_GLOBAL);
 	if (dl == NULL) {
 		/* shouldn't happen, really */
 		if (!silent)

--- a/src/mal/mal/mal_linker.h
+++ b/src/mal/mal/mal_linker.h
@@ -23,6 +23,10 @@
 
 /* #define DEBUG_MAL_LINKER */
 #define MONET64 1
+
+mal_export void freeMonetDB5LibraryPath(void);
+mal_export int setMonetDB5LibraryPath(const char* path);
+
 mal_export MALfcn getAddress(stream *out, str filename, str fcnname,int silent);
 mal_export char *MSP_locate_sqlscript(const char *mod_name, bit recurse);
 mal_export str loadLibrary(str modulename, int flag);


### PR DESCRIPTION
Hello Hannes! I need to set the full path for the libmonetdb5 in MonetDBJavaLite, because the JVM is messing somehow with the path. Thanks!