### PR TITLE
Fixed 'undefined reference to function' errors

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -369,5 +369,5 @@ add_executable(readme
         tests/readme/readme.c
 )
 
-target_link_libraries(readme monetdb5)
+target_link_libraries(readme monetdb5 pthread dl m)
 


### PR DESCRIPTION
libmonetdb5.so: undefined reference to function `tanhf'
libmonetdb5.so: undefined reference to function `fetestexcept'
libmonetdb5.so: undefined reference to function `dlopen'
libmonetdb5.so: undefined reference to function `sinf'
libmonetdb5.so: undefined reference to function `sinh'
libmonetdb5.so: undefined reference to function `pthread_attr_setstacksize'
libmonetdb5.so: undefined reference to function `logf'
libmonetdb5.so: undefined reference to function `powf'
libmonetdb5.so: undefined reference to function `ceil'
libmonetdb5.so: undefined reference to function `atan2'
libmonetdb5.so: undefined reference to function `tanf'
libmonetdb5.so: undefined reference to function `tanh'
libmonetdb5.so: undefined reference to function `coshf'
libmonetdb5.so: undefined reference to function `atanf'
libmonetdb5.so: undefined reference to function `cosf'
libmonetdb5.so: undefined reference to function `cosh'
libmonetdb5.so: undefined reference to function `fmod'
libmonetdb5.so: undefined reference to function `fmodf'
libmonetdb5.so: undefined reference to function `acosf'
libmonetdb5.so: undefined reference to function `expf'
libmonetdb5.so: undefined reference to function `acos'
libmonetdb5.so: undefined reference to function `floorf'
libmonetdb5.so: undefined reference to function `sin'
libmonetdb5.so: undefined reference to function `cbrtf'
libmonetdb5.so: undefined reference to function `atan'
libmonetdb5.so: undefined reference to function `asin'
libmonetdb5.so: undefined reference to function `pthread_kill'
libmonetdb5.so: undefined reference to function `exp'
libmonetdb5.so: undefined reference to function `sqrtf'
libmonetdb5.so: undefined reference to function `ceilf'
libmonetdb5.so: undefined reference to function `trunc'
libmonetdb5.so: undefined reference to function `tan'
libmonetdb5.so: undefined reference to function `dlsym'
libmonetdb5.so: undefined reference to function `cbrt'
libmonetdb5.so: undefined reference to function `nextafter'
libmonetdb5.so: undefined reference to function `pthread_join'
libmonetdb5.so: undefined reference to function `cos'
libmonetdb5.so: undefined reference to function `pthread_create'
libmonetdb5.so: undefined reference to function `feclearexcept'
libmonetdb5.so: undefined reference to function `log'
libmonetdb5.so: undefined reference to function `pow'
libmonetdb5.so: undefined reference to function `round'
libmonetdb5.so: undefined reference to function `log10f'
libmonetdb5.so: undefined reference to function `nextafterf'
libmonetdb5.so: undefined reference to function `log10'
libmonetdb5.so: undefined reference to function `sqrt'
libmonetdb5.so: undefined reference to function `asinf'
libmonetdb5.so: undefined reference to function `roundf'
libmonetdb5.so: undefined reference to function `atan2f'
libmonetdb5.so: undefined reference to function `sinhf'
libmonetdb5.so: undefined reference to function `floor'
collect2: error: ld returned 1 exit status