### PR TITLE
Update src/embedded/embedded.c

### DIFF
--- a/src/embedded/embedded.c
+++ b/src/embedded/embedded.c
@@ -482,8 +482,8 @@ void monetdb_unregister_progress(monetdb_connection conn) {
 	}
 	MT_lock_set(&c->progress_lock);
 	c->progress_callback = NULL;
-	if(c->progress_data)
-		free(c->progress_data);
+	//if(c->progress_data)
+		//free(c->progress_data);
 	c->progress_data = NULL;
 	MT_lock_unset(&c->progress_lock);
 }


### PR DESCRIPTION
progress_data is owned by the application and should not be released by the library.
progress_data is passed in void monetdb_register_progress(monetdb_connection conn, monetdb_progress_callback callback, void* data);